### PR TITLE
add analyzeExpense to permissions

### DIFF
--- a/dist/idp-deploy.yaml
+++ b/dist/idp-deploy.yaml
@@ -116,6 +116,7 @@ Resources:
                   - textract:DetectDocumentText
                   - textract:StartDocumentAnalysis
                   - textract:StartDocumentTextDetection
+                  - textract:AnalyzeExpense
                   - comprehend:DetectEntities
                   - comprehend:DetectPiiEntities
                   - comprehend:ContainsPiiEntities


### PR DESCRIPTION
*Issue #, if available:*
error below occurs when running section 12: invoices and receipts processing of module 2
is not authorized to perform: textract:AnalyzeExpense because no identity-based policy allows the textract:AnalyzeExpense action

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
