### PR TITLE
GenAI - Ramp up - Amazon SageMaker Jumpstart

### DIFF
--- a/00-llm-sagemaker-jumpstart.ipynb
+++ b/00-llm-sagemaker-jumpstart.ipynb
@@ -1,0 +1,1071 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Question Answering with Extracted Documents\n",
+    "\n",
+    "There are three ways to run Large Language Models (LLMs) models on AWS: \n",
+    "\n",
+    "(1) AI services: Amazon Bedrock  \n",
+    "(2) Amazon SageMaker and Amazon SageMaker JumpStart  \n",
+    "(3) ML Infrastructure  \n",
+    "\n",
+    "In this notebook, we focus on (2) Amazon SageMaker JumpStart. \n",
+    "\n",
+    "Foundation models are ML models that are capable of understanding and generating human-like language at a massive scale. These LLMs are trained on vast amounts of text data, often on the order of billions of words or more, using techniques such as unsupervised learning and self-supervised learning. Amazon SageMaker JumpStart offers state-of-the-art, [**built-in foundation models**](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models-choose.html) which can be used to build your own generative AI solutions and integrate custom solutions with additional SageMaker features. \n",
+    "\n",
+    "Amazon SageMaker JumpStart provides solution templates that set up infrastructure for common use cases, and executable example notebooks for machine learning with SageMaker. You can access the pre-trained models, solution templates, and examples through the JumpStart landing page in Amazon SageMaker Studio or by using the SageMaker Python SDK. To find out more, read the SageMaker Jumpstart documentation [here](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html).\n",
+    "\n",
+    "You can now also fine-tune models with your own custom data set to improve performance in specific domains. For example, this [blog](https://aws.amazon.com/blogs/machine-learning/domain-adaptation-fine-tuning-of-foundation-models-in-amazon-sagemaker-jumpstart-on-financial-data/) describes how to use domain adaption to fine tune a GPT-J 6B model on publicly available financial data so that the model can generate more relevant text for financial services use cases.\n",
+    "\n",
+    "Within Amazon SageMaker Jumpstart, there are models that can perform text to text(text2text) generation tasks, such as [**BloomZ 7B1**](https://huggingface.co/bigscience/bloomz-7b1), [**Flan T5 XXL**](https://huggingface.co/google/flan-t5-xxl), and [**Flan T5 UL2**](https://huggingface.co/google/flan-ul2). These models can respond to user questions with generated text answers.\n",
+    "\n",
+    "In this notebook, we will demonstrate:\n",
+    "\n",
+    "* (1) How to deploy a LLM in SageMaker JumpStart.\n",
+    "* (2) Common use cases of LLMs.\n",
+    "* (3) How to ask a question to a LLM with and without providing the context.\n",
+    "\n",
+    "**This notebook serves a template such that you can easily replace the sample dataset with your own to build a custom question and answering application.**"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1. Deploy a LLM in SageMaker JumpStart\n",
+    "\n",
+    "To better illustrate the idea, let's first deploy the model that is required to perform the demo. You will need to (1) install the required python packages, (2)  authenticate the use of AWS services by using an AWS role, (3) define the parse response functions, (4) select a model, (5) deploy the model\n",
+    "\n",
+    "When you deploy a model from JumpStart, SageMaker hosts the model and deploys an endpoint that you can use for inference. In this notebook, we focus on the deployment of Flan T5 and demo with the Flan T5 SageMaker endpoint. \n",
+    "\n",
+    "(Optional) You may extend the notebook by uncommenting the `_MODEL_CONFIG_` python dictionary defined as below to compare the performance between the Flan T5 XL, BloomZ 7B1, and Flan UL2 models."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Install Libraries"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before executing the notebook, there are some initial steps required for set up. This notebook requires latest version of sagemaker and ipywidgets.\n",
+    "\n",
+    "The ipywidgets library allows you to use interactive browser controls for Jupyter notebooks. Examples include basic form controls like sliders, checkboxes and text inputs, and advanced controls like 2d and 3d visualizations.\n",
+    "\n",
+    "The Amazon SageMaker Python SDK, shown below as sagemaker, is an open source library for training and deploying machine-learned models on Amazon SageMaker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade pip\n",
+    "!pip install --upgrade sagemaker --quiet\n",
+    "!pip install ipywidgets==7.0.0 --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Initiate SageMaker Session, and AWS Role\n",
+    "\n",
+    "To train and host on Amazon SageMaker, we need to set up and authenticate the use of AWS services. Here, we use the execution role associated with the current notebook instance as the AWS account role with SageMaker access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import sagemaker, boto3, json\n",
+    "from sagemaker.session import Session\n",
+    "from sagemaker.model import Model\n",
+    "from sagemaker import image_uris, model_uris, script_uris, hyperparameters\n",
+    "from sagemaker.predictor import Predictor\n",
+    "from sagemaker.utils import name_from_base\n",
+    "\n",
+    "sagemaker_session = Session()\n",
+    "aws_role = sagemaker_session.get_caller_identity_arn()\n",
+    "aws_region = boto3.Session().region_name\n",
+    "sess = sagemaker.Session()\n",
+    "model_version = \"*\"\n",
+    "\n",
+    "print(aws_role)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Define the Response Parser\n",
+    "\n",
+    "The below cell includes three functions that outline how you are going to interact with the model’s endpoint, and how you want the output to be formatted. \n",
+    "\n",
+    "The **query_endpoint_with_json_payload** function specifies that the input to the model's endpoint is any string of text formatted as json and encoded in utf-8 format. \n",
+    "\n",
+    "Both the **parse_response_model_flan_t5** and **parse_response_multiple_texts_bloomz** functions are specific to their respective models, and they ensure that the output from the endpoint is formatted as json and includes the generated text.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "#Defining the parse functions for all of the available models\n",
+    "\n",
+    "def query_endpoint_with_json_payload(encoded_json, endpoint_name, content_type=\"application/json\"):\n",
+    "    client = boto3.client(\"runtime.sagemaker\")\n",
+    "    response = client.invoke_endpoint(\n",
+    "        EndpointName=endpoint_name, ContentType=content_type, Body=encoded_json\n",
+    "    )\n",
+    "    return response\n",
+    "\n",
+    "def parse_response_model_flan_t5(query_response):\n",
+    "    model_predictions = json.loads(query_response[\"Body\"].read())\n",
+    "    generated_text = model_predictions[\"generated_texts\"]\n",
+    "    return generated_text\n",
+    "\n",
+    "\n",
+    "def parse_response_multiple_texts_bloomz(query_response):\n",
+    "    generated_text = []\n",
+    "    model_predictions = json.loads(query_response[\"Body\"].read())\n",
+    "    for x in model_predictions[0]:\n",
+    "        generated_text.append(x[\"generated_text\"])\n",
+    "    return generated_text"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Select an LLM to Deploy\n",
+    "\n",
+    "As mentioned previously, Amazon SageMaker Jumpstart provides access to hundreds of built-in algorithms with pretrained models from popular model hubs. You can check [the available models](https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html) on Amazon SageMaker Jumpstart to get the full available model list.\n",
+    "\n",
+    "You are able to chose the right EC2 instance type to fit your ML use case. The Amazon SageMaker documentation suggests a few different instance types [here](https://docs.aws.amazon.com/sagemaker/latest/dg/cmn-info-instance-types.html), where you can also view their associated costs. You can also use [Amazon SageMaker Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to help you select the best instance type and configuration for your ML models and workloads.\n",
+    "\n",
+    "By default, the following cell deploys the huggingface-text2text-flan-t5-small with a ml.g5.xlarge instance.\n",
+    "\n",
+    "(Optional) Feel free to uncomment the _MODEL_CONFIG_ python dictionary to compare the performance between the Flan T5 XL, BloomZ 7B1, and Flan UL2 models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "_MODEL_CONFIG_ = {\n",
+    "    \"huggingface-text2text-flan-t5-small\": {\n",
+    "        \"instance type\": \"ml.g5.xlarge\",\n",
+    "        \"env\": {\"TS_DEFAULT_WORKERS_PER_MODEL\": \"1\"},\n",
+    "        \"parse_function\": parse_response_model_flan_t5,\n",
+    "        \"prompt\": \"\"\"Answer based on context:\\n\\n{context}\\n\\n{question}\"\"\",\n",
+    "    },\n",
+    "    # \"huggingface-textgeneration1-bloomz-7b1-fp16\": {\n",
+    "    #     \"instance type\": \"ml.g5.12xlarge\",\n",
+    "    #     \"env\": {},\n",
+    "    #     \"parse_function\": parse_response_multiple_texts_bloomz,\n",
+    "    #     \"prompt\": \"\"\"question: \\\"{question}\"\\\\n\\nContext: \\\"{context}\"\\\\n\\nAnswer:\"\"\",\n",
+    "    # },\n",
+    "    # \"huggingface-text2text-flan-ul2-bf16\": {\n",
+    "    #     \"instance type\": \"ml.g5.24xlarge\",\n",
+    "    #     \"env\": {\"TS_DEFAULT_WORKERS_PER_MODEL\": \"1\"},\n",
+    "    #     \"parse_function\": parse_response_model_flan_t5,\n",
+    "    #     \"prompt\": \"\"\"Answer based on context:\\n\\n{context}\\n\\n{question}\"\"\",\n",
+    "    # }\n",
+    "}"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Deploy a SageMaker Endpoint\n",
+    "\n",
+    "To deploy a SageMaker endpoint, you need to initiate a SageMaker [Model](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html) that can be deployed to an Endpoint. The mandatory parameters are: (1) deploy_image_uri, (2) model_uri, (3) model_inference, (4) model_predictor_inference\n",
+    "\n",
+    "**deploy_image_uri**: the URI of the inference container image to be deployed  \n",
+    "**model_id**: the model ID for the model to be deployed  \n",
+    "**endpoint_name**: the name of the endpoint that will be created for the model  \n",
+    "**inference_instance_type**: the instance type of the model to be deployed  \n",
+    "**model_uri**: the URI of the model to be deployed  \n",
+    "**model_inference**: the object containing all of the model's attributes  \n",
+    "**model_predictor_inference**: the object that will be used to deploy the model  \n",
+    "\n",
+    "The following cell can take around 5-10 minutes to process as we are deploying the model endpoint here.\n",
+    "\n",
+    "Please note if you decide to deploy multiple models, this cell will take longer to execute.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "newline, bold, unbold = \"\\n\", \"\\033[1m\", \"\\033[0m\"\n",
+    "\n",
+    "for model_id in _MODEL_CONFIG_:\n",
+    "    endpoint_name = name_from_base(f\"jumpstart-example-{model_id}\")\n",
+    "    inference_instance_type = _MODEL_CONFIG_[model_id][\"instance type\"]\n",
+    "\n",
+    "    # Retrieve the inference container uri. This is the base HuggingFace container image for the default model above.\n",
+    "    deploy_image_uri = image_uris.retrieve(\n",
+    "        region=None,\n",
+    "        framework=None,  # automatically inferred from model_id\n",
+    "        image_scope=\"inference\",\n",
+    "        model_id=model_id,\n",
+    "        model_version=model_version,\n",
+    "        instance_type=inference_instance_type,\n",
+    "    )\n",
+    "    # Retrieve the model uri.\n",
+    "    model_uri = model_uris.retrieve(\n",
+    "        model_id=model_id, model_version=model_version, model_scope=\"inference\"\n",
+    "    )\n",
+    "    model_inference = Model(\n",
+    "        image_uri=deploy_image_uri,\n",
+    "        model_data=model_uri,\n",
+    "        role=aws_role,\n",
+    "        predictor_cls=Predictor,\n",
+    "        name=endpoint_name,\n",
+    "        env=_MODEL_CONFIG_[model_id][\"env\"],\n",
+    "    )\n",
+    "    model_predictor_inference = model_inference.deploy(\n",
+    "        initial_instance_count=1,\n",
+    "        instance_type=inference_instance_type,\n",
+    "        predictor_cls=Predictor,\n",
+    "        endpoint_name=endpoint_name,\n",
+    "    )\n",
+    "    print(f\"{bold}Model {model_id} has been deployed successfully.{unbold}{newline}\")\n",
+    "    _MODEL_CONFIG_[model_id][\"endpoint_name\"] = endpoint_name"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hopefully you will have recieved a message that looks similar to this - \"-------!Model huggingface-text2text-flan-t5-small has been deployed successfully.\"\n",
+    "\n",
+    "If you're unable to deploy multiple models, make sure you check your **[AWS service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)** to see how you can request an instance limit increase."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this cell so we can reference the endpoint_name variable in lab 2.\n",
+    "%store endpoint_name"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "Now we've deployed our model, we can start using our newly created SageMaker endpoint for inference!\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2. Common use cases of LLMs"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A popular encoder-decoder model known as [T5](https://huggingface.co/docs/transformers/model_doc/t5) (Text-to-Text Transfer Transformer) is one such model that was subsequently fine-tuned via the Flan method to produce the [Flan-T5](https://huggingface.co/docs/transformers/model_doc/flan-t5) family of models. Flan-T5 is an instruction-tuned model and therefore is capable of performing various zero-shot Natural Language Processing (NLP) tasks, as well as few-shot in-context learning tasks. \n",
+    "\n",
+    "You can directly use the [FLAN-T5 model](https://huggingface.co/google/flan-t5-base) for many NLP tasks, without fine-tuning the model. Examples of these tasks include:\n",
+    "\n",
+    "\n",
+    "* Text summarization\n",
+    "* Common sense reasoning / natural language inference\n",
+    "* Question and answering\n",
+    "* Sentence / sentiment classification\n",
+    "* Translation\n",
+    "* Pronoun resolution\n",
+    "\n",
+    "The code below focuses on question and answering, but feel free to add your own use cases. Here are some sample queries you can test out: [Zero-shot prompting for the Flan-T5 foundation model in Amazon SageMaker JumpStart](https://aws.amazon.com/blogs/machine-learning/zero-shot-prompting-for-the-flan-t5-foundation-model-in-amazon-sagemaker-jumpstart/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "question = \"Briefly summarize this paragraph: Amazon Comprehend uses natural language processing (NLP) to extract insights about the content of documents. It develops insights by recognizing the entities, key phrases, language, sentiments, and other common elements in a document. Use Amazon Comprehend to create new products based on understanding the structure of documents. For example, using Amazon Comprehend you can search social networking feeds for mentions of products or scan an entire document repository for key phrases. You can access Amazon Comprehend document analysis capabilities using the Amazon Comprehend console or using the Amazon Comprehend APIs. You can run real-time analysis for small workloads or you can start asynchronous analysis jobs for large document sets. You can use the pre-trained models that Amazon Comprehend provides, or you can train your own custom models for classification and entity recognition. All of the Amazon Comprehend features accept UTF-8 text documents as the input. In addition, custom classification and custom entity recognition accept image files, PDF files, and Word files as input. Amazon Comprehend can examine and analyze documents in a variety of languages, depending on the specific feature. For more information, see Languages supported in Amazon Comprehend. Amazon Comprehend’s Dominant language capability can examine documents and determine the dominant language for a far wider selection of languages.\"\n",
+    "#question = \"translate: My name is Mia. to german\"\n",
+    "#question = \"Review:\\nThis moive is so great and once again dazzles and delights us\\nIs this movie review sentence negative or positive?\\nOPTIONS:\\n-positive \\n-negative\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should supply this question within a JSON payload when invoking the endpoint. This JSON payload can include any desired inference parameters that help control the model output, such as maximum sequence length and number of return sequences. To see the full list of payload parameters that can be used here, check out the [transformers library.](https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig)  \n",
+    "\n",
+    "\n",
+    "* **text_inputs** — The sequence used as a prompt for the generation or as model inputs to the encoder.\n",
+    "* **max_length** (`int`, *optional*, defaults to 20) — The model generates text until the output length (which includes the input context length) reaches max_length. If specified, it must be a positive integer.\n",
+    "* **num_return_sequences (`int`,** *optional*, defaults to 1) — The number of output sequences returned. If specified, it must be a positive integer.\n",
+    "* **top_k** (`int`, *optional*, defaults to 50) — In each step of text generation, sample from only the top_k most likely words. If specified, it must be a positive integer.\n",
+    "* **top_p** (`float`, *optional*, defaults to 1.0) — In each step of text generation, sample from the smallest possible set of words with cumulative probability top_p. If specified, it must be a float between 0–1.\n",
+    "* **do_sample** (`bool`, *optional*, defaults to `False`) — If True, sample the next word as per the likelihood. If specified, it must be Boolean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"text_inputs\": question,\n",
+    "    \"max_length\": 100,\n",
+    "    \"num_return_sequences\": 1,\n",
+    "    \"top_k\": 10,\n",
+    "    \"top_p\": 0.95, #0.95,\n",
+    "    \"do_sample\": True,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "for model_id in _MODEL_CONFIG_:\n",
+    "    endpoint_name = _MODEL_CONFIG_[model_id][\"endpoint_name\"]\n",
+    "    query_response = query_endpoint_with_json_payload(\n",
+    "        json.dumps(payload).encode(\"utf-8\"), endpoint_name=endpoint_name\n",
+    "    )\n",
+    "    generated_texts = _MODEL_CONFIG_[model_id][\"parse_function\"](query_response)\n",
+    "    print(f\"For model: {model_id}, the generated output is: {generated_texts[0]}\\n\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3. Ask a question to LLM with and without providing the context\n",
+    "\n",
+    "There are a few limitations of using off-the-shelf pre-trained LLMs:\n",
+    "\n",
+    "- They’re usually trained offline, making the model agnostic to the latest information (for example, a chatbot trained from 2011–2018 has no information about COVID-19).\n",
+    "\n",
+    "- They make predictions by only looking up information stored in its parameters, leading to inferior interpretability.\n",
+    "    \n",
+    "- They’re mostly trained on general domain corpora, making them less effective on domain-specific tasks. There are scenarios when you want models to generate text based on specific data rather than generic data. \n",
+    "\n",
+    "\n",
+    "\n",
+    "To better illustrate this, lets ask the model a question without providing the context and see how it responds.\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Ask a question without providing the context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "question2 = \"What is Susanne's job?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "payload = {\n",
+    "    \"text_inputs\": question2,\n",
+    "    \"max_length\": 100,\n",
+    "    \"num_return_sequences\": 10,\n",
+    "    \"top_k\": 3,\n",
+    "    \"top_p\": 0.95, #0.95,\n",
+    "    \"do_sample\": True,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "for model_id in _MODEL_CONFIG_:\n",
+    "    endpoint_name = _MODEL_CONFIG_[model_id][\"endpoint_name\"]\n",
+    "    query_response = query_endpoint_with_json_payload(\n",
+    "        json.dumps(payload).encode(\"utf-8\"), endpoint_name=endpoint_name\n",
+    "    )\n",
+    "    generated_texts = _MODEL_CONFIG_[model_id][\"parse_function\"](query_response)\n",
+    "    print(f\"For model: {model_id}, the generated output is: {generated_texts[0]}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see the generated answer is wrong or doesn't make much sense. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Improve the answer to the same question using **prompt engineering** with insightful context\n",
+    "\n",
+    "Currently, there are two popular ways to reference specific data in LLMs:\n",
+    "\n",
+    "- Insert data as context in the model prompt as a way to provide the information that the model can use while creating the result\n",
+    "\n",
+    "- Fine-tune the model by providing a file with prompt and completion pairs\n",
+    "\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will provide extra contextual information, insert it in a prompt, and send it to the model together with the question. Below is an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context = \"Peter is a professional footballer. Susanne, his partner, is a writer.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameters = {\n",
+    "    \"max_length\": 200,\n",
+    "    \"num_return_sequences\": 10,\n",
+    "    \"top_k\": 250,\n",
+    "    \"top_p\": 0.95,\n",
+    "    \"do_sample\": False,\n",
+    "    #\"temperature\": 1,\n",
+    "}\n",
+    "\n",
+    "for model_id in _MODEL_CONFIG_:\n",
+    "    endpoint_name = _MODEL_CONFIG_[model_id][\"endpoint_name\"]\n",
+    "\n",
+    "    prompt = _MODEL_CONFIG_[model_id][\"prompt\"]\n",
+    "\n",
+    "    text_input = prompt.replace(\"{context}\", context)\n",
+    "    text_input = text_input.replace(\"{question}\", question2)\n",
+    "    payload = {\"text_inputs\": text_input, **parameters}\n",
+    "\n",
+    "    query_response = query_endpoint_with_json_payload(\n",
+    "        json.dumps(payload).encode(\"utf-8\"), endpoint_name=endpoint_name\n",
+    "    )\n",
+    "    generated_texts = _MODEL_CONFIG_[model_id][\"parse_function\"](query_response)\n",
+    "    print(\n",
+    "        f\"{bold}For model: {model_id}, the generated output is: {generated_texts[0]}{unbold}{newline}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see now the model is able to answer the question correctly using the extra information provided as context! Feel free to ask your own questions + play around with the model you've deployed. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup\n",
+    "\n",
+    "Run the following to terminate your SageMaker endpoint. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sagemaker_client = boto3.client('sagemaker')\n",
+    "sagemaker_client.delete_endpoint(EndpointName=endpoint_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "availableInstances": [
+   {
+    "_defaultOrder": 0,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 4,
+    "name": "ml.t3.medium",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 1,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 8,
+    "name": "ml.t3.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 2,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 16,
+    "name": "ml.t3.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 3,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 32,
+    "name": "ml.t3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 4,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 8,
+    "name": "ml.m5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 5,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 16,
+    "name": "ml.m5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 6,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 32,
+    "name": "ml.m5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 7,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 64,
+    "name": "ml.m5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 8,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 128,
+    "name": "ml.m5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 9,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 192,
+    "name": "ml.m5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 10,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 256,
+    "name": "ml.m5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 11,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 384,
+    "name": "ml.m5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 12,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 8,
+    "name": "ml.m5d.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 13,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 16,
+    "name": "ml.m5d.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 14,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 32,
+    "name": "ml.m5d.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 15,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 64,
+    "name": "ml.m5d.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 16,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 128,
+    "name": "ml.m5d.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 17,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 192,
+    "name": "ml.m5d.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 18,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 256,
+    "name": "ml.m5d.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 19,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "memoryGiB": 384,
+    "name": "ml.m5d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 20,
+    "_isFastLaunch": true,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 4,
+    "name": "ml.c5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 21,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 8,
+    "name": "ml.c5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 22,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 16,
+    "name": "ml.c5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 23,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 32,
+    "name": "ml.c5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 24,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 72,
+    "name": "ml.c5.9xlarge",
+    "vcpuNum": 36
+   },
+   {
+    "_defaultOrder": 25,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 96,
+    "name": "ml.c5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 26,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 144,
+    "name": "ml.c5.18xlarge",
+    "vcpuNum": 72
+   },
+   {
+    "_defaultOrder": 27,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "memoryGiB": 192,
+    "name": "ml.c5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 28,
+    "_isFastLaunch": true,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 16,
+    "name": "ml.g4dn.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 29,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 32,
+    "name": "ml.g4dn.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 30,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 64,
+    "name": "ml.g4dn.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 31,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 128,
+    "name": "ml.g4dn.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 32,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "memoryGiB": 192,
+    "name": "ml.g4dn.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 33,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 256,
+    "name": "ml.g4dn.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 34,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 61,
+    "name": "ml.p3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 35,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "memoryGiB": 244,
+    "name": "ml.p3.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 36,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "memoryGiB": 488,
+    "name": "ml.p3.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 37,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "memoryGiB": 768,
+    "name": "ml.p3dn.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 38,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 16,
+    "name": "ml.r5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 39,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 32,
+    "name": "ml.r5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 40,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 64,
+    "name": "ml.r5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 41,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 128,
+    "name": "ml.r5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 42,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 256,
+    "name": "ml.r5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 43,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 384,
+    "name": "ml.r5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 44,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 512,
+    "name": "ml.r5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 45,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "memoryGiB": 768,
+    "name": "ml.r5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 46,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 16,
+    "name": "ml.g5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 47,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 32,
+    "name": "ml.g5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 48,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 64,
+    "name": "ml.g5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 49,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 128,
+    "name": "ml.g5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 50,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "memoryGiB": 256,
+    "name": "ml.g5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 51,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "memoryGiB": 192,
+    "name": "ml.g5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 52,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "memoryGiB": 384,
+    "name": "ml.g5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 53,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "memoryGiB": 768,
+    "name": "ml.g5.48xlarge",
+    "vcpuNum": 192
+   }
+  ],
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
The original GenAI lab includes the content straight to the Amazon SageMaker and integrates with other services. 

The developers of AI service like Amazon Textract and Amazon Comprehend, who have experienced REST API call and less experience with Amazon SageMaker. Hence, this notebook provides the developers an opportunity to ramp up the Amazon SageMaker skills.

In this notebook, we show: (1) How to deploy a LLM in Amazon SageMaker JumpStart, (2) Common use cases of LLMs, and (3) How to ask a question to a LLM with and without providing the context. The expected effort will take about 15 mins to run through the whole notebook, including 5-10 minutes model deployment.

Through the samples in the notebook, developers can learn the basic of Amazon SageMaker Jumpstart, Model deployment, and prompt to start their learning of 01-idp-genai-qna.ipynb.

*Issue #, if available:*
NA

*Description of changes:*
Add Amazon SageMaker Jumpstart notebook

*Note*
A joint PR of miachang@ and klssmk@.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
