### PR TITLE
when using it in a new Studio Classic Domain in us-east-1, is requires the anthropic libs to be installed

### DIFF
--- a/gen-ai/01-idp-genai-bedrock.ipynb
+++ b/gen-ai/01-idp-genai-bedrock.ipynb
@@ -139,6 +139,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "d80f54e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install anthropic"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 28,
    "id": "4212bb6d-9069-4f34-a684-4d7d1750e6a6",
    "metadata": {


### PR DESCRIPTION
After installing the Anthropic dependency before the Step "2. Summarization" and restarted the notebook, the cell run without errors 