### PR TITLE
Update idp-deploy.yaml with additional permission for Comprehend Job

### DIFF
--- a/dist/idp-deploy.yaml
+++ b/dist/idp-deploy.yaml
@@ -227,6 +227,7 @@ Resources:
                   - comprehendmedical:StartRxNormInferenceJob
                   - comprehendmedical:StartSNOMEDCTInferenceJob
                   - comprehendmedical:StartPHIDetectionJob
+                  - comprehend:StartDocumentClassificationJob
                 Resource: '*'
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
Please refer to this issue submitted: https://github.com/aws-samples/aws-ai-intelligent-document-processing/issues/45

*Issue #, if available:*
On step 5, there is a missing permission for Sagemaker Execution Role to start the Comprehend Classification Job. The missing permission is `comprehend:StartDocumentClassificationJob` under **textract-comprehend-sl-access policy**. Once adding this additional action, it will not run the comprehend job.

*Description of changes:*
Updated the idp-deploy.yaml file with the additional permission: `comprehend:StartDocumentClassificationJob`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
