### PR TITLE
Remove deprecated KernelGatewayApp from CloudFormation template

### DIFF
--- a/dist/idp-deploy.yaml
+++ b/dist/idp-deploy.yaml
@@ -400,21 +400,6 @@ Resources:
       DomainId: !GetAtt StudioDomain.DomainId
       UserProfileName: !Ref UserProfileName
 
-  DataScienceApp:
-    Type: AWS::SageMaker::App
-    DependsOn: UserProfile
-    Properties:
-      AppName: instance-event-engine-datascience-ml-t3-medium
-      AppType: KernelGateway
-      DomainId: !GetAtt StudioDomain.DomainId
-      ResourceSpec:
-        InstanceType:  ml.t3.medium
-        SageMakerImageArn: !FindInMap
-          - RegionMap
-          - !Ref 'AWS::Region'
-          - datascience
-      UserProfileName: !Ref UserProfileName
-
 ### S3 Bucket For A2I
   A2IBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
Fixes #53

SageMaker Studio no longer supports AppType=KernelGateway.
The stack fails with:
"Invalid request provided: Invalid AppType [KernelGateway]. This AppType has been deprecated."

Changes:
- Removed DataScienceApp (KernelGateway) from the template
- Rely on the existing JupyterServer app (already created as 'default')

Result:
- CloudFormation completes successfully
- Lifecycle config still clones the workshop repo
